### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ example/dist.js
 example/dist.js.map
 test/output/*.js
 test/output/*.js.map
+.idea/
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class RollupTask extends TaskKitTask {
   }
 
   process(input, filename, done) {
-    this.options.rollup.bundle.sourcemap = this.options.sourcemaps;
+    this.options.rollup.bundle.sourcemap = this.options.sourcemap;
     const babelPresets = [
       [es2015, { modules: false }]
     ];
@@ -89,7 +89,7 @@ class RollupTask extends TaskKitTask {
           if (!result) {
             return done(new Error(`${input} resulted in an empty bundle`));
           }
-          if (!this.options.sourcemaps) {
+          if (!this.options.sourcemap) {
             return this.write(filename, result.code, done);
           }
           //write sourcemap

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const babelHelpers = require('babel-plugin-external-helpers');
 const path = require('path');
 
 class RollupTask extends TaskKitTask {
-
   get description() {
     return 'Compiles your various client-executable files into a minified, source-mapped, browser-compatible js file that you can embed in a webpage';
   }

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ class RollupTask extends TaskKitTask {
     return {
       multithread: false,
       minify: (process.env.NODE_ENV === 'production'),
+      sourcemap: true,
       rollup: {
         bundle: {
           format: 'iife',
-          name: 'app',
-          sourcemap: true,
+          name: 'app'
         },
         external: []
       },

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class RollupTask extends TaskKitTask {
         bundle: {
           format: 'iife',
           name: 'app',
-          sourcemap: true,
+          sourcemap: this.options.sourcemap,
         },
         external: []
       },

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class RollupTask extends TaskKitTask {
         bundle: {
           format: 'iife',
           name: 'app',
-          sourcemap: this.options.sourcemap,
+          sourcemap: true,
         },
         external: []
       },

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "domassist": "^1.10.0",
-    "eslint": "3.14.0",
-    "eslint-config-firstandthird": "3.2.0",
-    "eslint-plugin-import": "2.2.0",
+    "eslint": "^4.15.0",
+    "eslint-config-firstandthird": "^4.3.0",
+    "eslint-plugin-import": "^2.8.0",
     "tap": "^11.0.1"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "TaskKit for Rollup",
   "main": "index.js",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "eslint . && tap test/*.js"
   },
   "repository": {
     "type": "git",
@@ -45,5 +45,11 @@
   },
   "eslintConfig": {
     "extends": "firstandthird"
-  }
+  },
+  "eslintIgnore": [
+    "test/input",
+    "test/output",
+    "test/expected",
+    "example"
+  ]
 }

--- a/test/rollup.test.js
+++ b/test/rollup.test.js
@@ -2,6 +2,15 @@ const tap = require('tap');
 const TaskkitRollup = require('../');
 const fs = require('fs');
 
+const clean = () => {
+  try {
+    fs.unlinkSync('./test/output/domassist.js');
+    fs.unlinkSync('./test/output/domassist.js.map');
+  } catch (e) {
+    // Fail silently
+  }
+};
+
 tap.test('setup', (t) => {
   t.plan(2);
 
@@ -15,15 +24,15 @@ tap.test('process', (t) => {
   t.plan(2);
 
   const rollup = new TaskkitRollup('rollup', {
-    sourcemaps: true
+    sourcemap: true,
+    files: {
+      './test/output/domassist.js': './test/input/domassist.js'
+    }
   });
 
-  try {
-    fs.unlinkSync('./test/output/domassist.js');
-    fs.unlinkSync('./test/output/domassist.js.map');
-  } catch (e) {}
+  clean();
 
-  rollup.process('./test/input/domassist.js', './test/output/domassist.js', (err) => {
+  rollup.execute((err, results) => {
     if (err) {
       throw err;
     }
@@ -42,15 +51,15 @@ tap.test('map file disabled', (t) => {
   t.plan(2);
 
   const rollup = new TaskkitRollup('rollup', {
-    sourcemaps: false
+    sourcemap: false,
+    files: {
+      './test/output/domassist.js': './test/input/domassist.js'
+    }
   });
 
-  try {
-    fs.unlinkSync('./test/output/domassist.js');
-    fs.unlinkSync('./test/output/domassist.js.map');
-  } catch (e) {}
+  clean();
 
-  rollup.process('./test/input/domassist.js', './test/output/domassist.js', (err) => {
+  rollup.execute((err, results) => {
     if (err) {
       throw err;
     }
@@ -59,3 +68,4 @@ tap.test('map file disabled', (t) => {
     t.equal(fs.existsSync('./test/output/domassist.js.map'), false, 'map wasn\'t created');
   });
 });
+

--- a/test/rollup.test.js
+++ b/test/rollup.test.js
@@ -24,7 +24,6 @@ tap.test('process', (t) => {
   t.plan(2);
 
   const rollup = new TaskkitRollup('rollup', {
-    sourcemap: true,
     files: {
       './test/output/domassist.js': './test/input/domassist.js'
     }


### PR DESCRIPTION
Proposing some changes here:

* `sourcemaps` to `sourcemap`: This is for consistency. We use sourcemap on `clientkit-css` so it seemed odd to get a different one. If you prefer plural I'll make a PR to clientkit-css instead.
* `sourcemap` didn't use a proper default:

```js
return {      
      rollup: {
        bundle: {
          format: 'iife',
          sourcemap: true
          name: 'app'
        },
        external: []
      }
}
```

Was then being used with `this.options.rollup.bundle.sourcemap = this.options.sourcemap;`. And that lead to an unwanted `undefined`

* Tests updates: Instead of using `process`, just using execute. Again this is to keep it consistent between both repos. I bet it'll be that too whenever we migrate to 2.X since that's the function being `await`ed.
* `^` versions for package.json. Update deps got some of them out unless breaking we should be updating by default. This is what we do usually too in our libraries (FE at least)

@orthagonal and @jgallen23 let me know your thoughts
  
 
  